### PR TITLE
Fix back button dashboard

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -43,7 +43,7 @@ export default {
   },
 
   loggedIn() {
-    return localStorage.token
+    return !!localStorage.token
   },
 
   isManager() {

--- a/src/auth.js
+++ b/src/auth.js
@@ -43,7 +43,7 @@ export default {
   },
 
   loggedIn() {
-    return !!localStorage.token
+    return localStorage.token
   },
 
   isManager() {

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -79,9 +79,9 @@ export default {
           this.error = true
         } else {
           if (auth.isManager()) {
-            this.$router.replace(this.$route.query.redirect || "/datamanager")
+           this.$router.replace(this.$route.query.redirect || "/datamanager")
           } else {
-            this.$router.replace(this.$route.query.redirect || "/dashboard")
+            window.location.href = '/dashboard'
           }
         }
       })


### PR DESCRIPTION
I dont think this will break the deployed site, but I can't remember if we used this to solve that problem?
`this.$router.replace(this.$route.query.redirect || "/datamanager")`.

- Adds another stage for the browser to successfully go back to the dashboard not the login page.